### PR TITLE
Allow use of framework.io for command line builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.pioenvs

--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
 Arduino code for Clockwork Butterfly's big performance in July 2016.
+
+Sample usage for an Arduino Uno after
+[installing platform.io](http://docs.platformio.org/en/latest/installation.html):
+```
+platformio run -e arduinouno --target upload
+```
+
+Or for a Teensy:
+```
+platformio run -e teensy --target upload
+```
+
+Or to build for all platforms specified in the [`platformio.ini`](platformio.ini):
+```
+platformio run
+```

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,0 +1,22 @@
+#
+# Project Configuration File
+#
+# A detailed documentation with the EXAMPLES is located here:
+# http://docs.platformio.org/en/latest/projectconf.html
+#
+
+[platformio]
+src_dir = .
+
+[env:arduinouno]
+platform = atmelavr
+framework = arduino
+board = uno
+
+[env:teensy]
+platform = teensy
+framework = arduino
+board = teensy30
+
+# Automatic targets - enable auto-uploading
+# targets = upload


### PR DESCRIPTION
I'd like to be able to build this project from the command line instead of using the arduino IDE.

While you can use the arduino IDE [headlessly](https://github.com/arduino/Arduino/blob/master/build/shared/manpage.adoc), it's pretty slow (**8s** for this project even without upload and with no changes since previous build) so it's not very enjoyable to use. Because of that I suggest [platform.io](http://platformio.org/get-started/cli) instead.

This option only takes **1.2s** for a clean build. Something that's also useful is that you can build for multiple targets at once (to prevent issues like #14)
